### PR TITLE
Remove obsolete providing_args argument from Signal call for Django 4 compatibility

### DIFF
--- a/ajaxuploader/signals.py
+++ b/ajaxuploader/signals.py
@@ -1,4 +1,4 @@
 from django.dispatch import Signal
 
 
-file_uploaded = Signal(providing_args=['backend', 'request'])
+file_uploaded = Signal()


### PR DESCRIPTION
`providing_args` was a documentation field in Django 2.  It was deprecated in Django 3, and removed in Django 4 per https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-4-0